### PR TITLE
need clang5.0. added map to morph a type

### DIFF
--- a/include/at.hpp
+++ b/include/at.hpp
@@ -6,12 +6,20 @@
 #define TYPEUTIL_AT_HPP__
 #include <type_traits>
 #include <utility>
-#include <iostream>
+#include <tuple>
 
 namespace typu {
 
 template < typename ... Ts >
 struct type_list {
+	/* deduce from arg  */
+	template < template < typename ... > class Compo >
+	static constexpr auto rewrap(type_list<Ts...>&&) -> Compo< Ts... >;
+
+	template < template < typename ... > class Compo >
+	using rewrap_t = Compo< Ts ... >;
+
+	template < typename T >	using cons = type_list< Ts..., T >;
 };
 
 template <size_t Idx, size_t I, typename... Ts>
@@ -43,7 +51,7 @@ struct at_types
 	constexpr static decltype(auto) from_ts(type_list< As... >&&)
 	{
 		static_assert(sizeof...(As) > Idx, "Idx out of range");
-		return std::declval< typename at_type< Idx, As... >::type >();
+		return typename at_type< Idx, As... >::type{};
 	}
 
 	using type = decltype(from_ts(std::declval< Ts >()));
@@ -66,7 +74,7 @@ struct to_types_impl< Idx, I, CAR, CDR... > {
 	template < typename... AccTs >
 	constexpr static decltype(auto) to(std::tuple< AccTs ... >&& acc)
 	{
-		return to_types_impl< Idx, I + 1, CDR...>::template to(std::tuple_cat(acc, std::declval< std::tuple< CAR > >()));
+		return to_types_impl< Idx, I + 1, CDR...>::template to(std::tuple_cat(acc, std::tuple< CAR >{}));
 	}
 };
 

--- a/include/str.hpp
+++ b/include/str.hpp
@@ -71,7 +71,7 @@ struct chtype {
 
 
 /* DJB hash: Õ“Ë‚ª’m‚ç‚ê‚Ä‚¢‚é‚Ì‚Å’ˆÓ */
-constexpr uint64_t operator ""_hash(const char* str, size_t l)
+constexpr uint64_t operator ""_hash(const char* str, std::size_t l)
 {
 	uint64_t h = 5381;
 	chtype< char > c('\0');
@@ -82,7 +82,7 @@ constexpr uint64_t operator ""_hash(const char* str, size_t l)
 	return h;
 }
 
-constexpr size_t length(const char* str) { return str[0] != 0 ? 1 + length(str + 1) : 0; }
+constexpr std::size_t length(const char* str) { return str[0] != 0 ? 1 + length(str + 1) : 0; }
 
 #if defined(__GNUC__)
 /* gcc/clang ‚Å‚Í GNU extension ‚Æ‚µ‚Ä‚±‚Ì literal operator ‚ªg‚¦‚é. */

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 all:
-	clang++-3.5 -std=c++14 -stdlib=libc++ -I../include recurse.cpp -o recurse
-	clang++-3.5 -std=c++14 -stdlib=libc++ -I../include at.cpp -o at
-	clang++-3.5 -std=c++14 -stdlib=libc++ -I../include lu.cpp -o lu
-	clang++-3.5 -std=c++14 -stdlib=libc++ -I../include strings.cpp -o strings
+	clang++ -std=c++14 -I../include recurse.cpp -o recurse
+	clang++ -std=c++14 -I../include at.cpp -o at
+	clang++ -std=c++14 -I../include lu.cpp -o lu
+	clang++ -std=c++14 -I../include strings.cpp -o strings
+	clang++ -std=c++14 -I../include map.cpp -o map

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -14,6 +14,7 @@ using namespace typu;
 template <> struct mapto< int > : public base_mapper< void > {} ;
 template <> struct mapto< char > : public base_mapper< uint8_t > {};
 template <> struct mapto< float[16] > : public base_mapper< matrix > {};
+template <> struct mapto< std::array< float, 16 > > : public base_mapper< matrix > {};
 
 template < typename In > struct mapto2 { using type = void; };
 
@@ -36,7 +37,16 @@ int main()
 
 	using T3 = type_t< agg_t< int, type_t< agg_t< int, int, float[16] >, 16 >, char >, 0 >;
 	printf("T3 -> %s\n", abi::__cxa_demangle(typeid(typename morph< T3, mapto >::mapped).name(), 0, 0, &status));
-	return 0;
 
+	/* KNOWN ISSUE: 
+	   native の配列を型パラメータに与えると(配列を関数の戻り値にできないため) lu で lookup できなくなる. 
+	   std::array を使えば問題ないが互換性はない.
+	*/
+	using T4 = type_t< agg_t< int, named_t< "matrix"_hash, type_t< agg_t< int, int, std::array< float, 16 > >, 16 > >, char >, 0 >;
+	using S4 = typename lu< T4, "matrix"_hash >::type;
+	printf("S4 %s\n", abi::__cxa_demangle(typeid(S4).name(), 0, 0, &status));
+	printf("T4 -> %s\n", abi::__cxa_demangle(typeid(typename morph< S4, mapto >::mapped).name(), 0, 0, &status));
+
+	return 0;
 }
 

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <aggregate.hpp>
+#include <lookup.hpp>
+#include <str.hpp>
+#include <type_traits>
+#include <typeinfo>
+#include <stdint.h>
+#include <cxxabi.h>
+
+struct matrix { float m[16]; };
+
+using namespace typu;
+/* map に渡す式は M< typename >::type の形で変換後の型を導ければなんでもよいが, mapto< In >/base_mapper< Out > ヘルパを使う. */
+template <> struct mapto< int > : public base_mapper< void > {} ;
+template <> struct mapto< char > : public base_mapper< uint8_t > {};
+template <> struct mapto< float[16] > : public base_mapper< matrix > {};
+
+template < typename In > struct mapto2 { using type = void; };
+
+template < typename In > struct mapto3 { using type = In; };
+template <> struct mapto3< agg_t< int, int > > { using type = agg_t< char, int, char >; };
+
+int main()
+{
+	int status;
+	using T0 = type_t< agg_t< long, int, int, char >, 0 >;
+	printf("T0 -> %s\n", abi::__cxa_demangle(typeid(typename morph< T0, mapto >::mapped).name(), 0, 0, &status));
+
+	/* 空になった集積型は消える. 
+	   KNOWN ISSUE: type_t が空を収容することになるとコンパイルエラーになる */
+	using T1 = type_t< agg_t< int, agg_t< int, int >, char >, 0 >;
+	printf("T1 -> %s\n", abi::__cxa_demangle(typeid(typename morph< T1, mapto >::mapped).name(), 0, 0, &status));
+
+	using T2 = type_t< agg_t< int, agg_t< int, int >, char >, 0 >;
+	printf("T2 -> %s\n", abi::__cxa_demangle(typeid(typename morph< T2, mapto3 >::mapped).name(), 0, 0, &status));
+
+	using T3 = type_t< agg_t< int, type_t< agg_t< int, int, float[16] >, 16 >, char >, 0 >;
+	printf("T3 -> %s\n", abi::__cxa_demangle(typeid(typename morph< T3, mapto >::mapped).name(), 0, 0, &status));
+	return 0;
+
+}
+

--- a/test/recurse.cpp
+++ b/test/recurse.cpp
@@ -4,6 +4,7 @@
  */
 #include <stdio.h>
 #include <aggregate.hpp>
+#include <string.h>
 
 int main()
 {


### PR DESCRIPTION
* clang-6.0.0 support (need clang-5.0.0  or newer)
* added `moprh` public interface  to morth a type to another
